### PR TITLE
feat: configurable close button — hide to tray or quit (#8)

### DIFF
--- a/app.go
+++ b/app.go
@@ -14,6 +14,7 @@ import (
 	"ssh-tunnel-manager/internal/autostart"
 	"ssh-tunnel-manager/internal/config"
 	"ssh-tunnel-manager/internal/keychain"
+	"ssh-tunnel-manager/internal/prefs"
 	"ssh-tunnel-manager/internal/ssh"
 	"ssh-tunnel-manager/internal/sshconfig"
 	"ssh-tunnel-manager/internal/tray"
@@ -24,6 +25,7 @@ import (
 type App struct {
 	ctx         context.Context
 	store       *config.Store
+	prefs       *prefs.Store
 	manager     *ssh.Manager
 	termMgr     *ssh.TerminalManager
 	tray        *tray.Tray
@@ -43,9 +45,10 @@ type App struct {
 }
 
 // NewApp creates a new App instance.
-func NewApp(store *config.Store, startHidden bool) *App {
+func NewApp(store *config.Store, prefsStore *prefs.Store, startHidden bool) *App {
 	app := &App{
 		store:       store,
+		prefs:       prefsStore,
 		startHidden: startHidden,
 		logBuf:      make(map[string][]config.LogEntry),
 	}
@@ -546,4 +549,17 @@ type tunnelNotFoundError struct {
 
 func (e *tunnelNotFoundError) Error() string {
 	return "tunnel not found: " + e.id
+}
+
+// GetCloseToTray returns whether the window close button hides to tray (true)
+// or quits the application (false).
+func (a *App) GetCloseToTray() bool {
+	return a.prefs.Get().CloseToTray
+}
+
+// SetCloseToTray configures the close button behaviour and persists the setting.
+func (a *App) SetCloseToTray(enabled bool) error {
+	p := a.prefs.Get()
+	p.CloseToTray = enabled
+	return a.prefs.Set(p)
 }

--- a/frontend/src/components/SettingsPanel.svelte
+++ b/frontend/src/components/SettingsPanel.svelte
@@ -1,12 +1,14 @@
 <script lang="ts">
   import { onMount, onDestroy, createEventDispatcher } from "svelte";
-  import { GetAutostart, SetAutostart, GetCurrentVersion, CheckForUpdate, InstallUpdate } from "../../wailsjs/go/main/App";
+  import { GetAutostart, SetAutostart, GetCloseToTray, SetCloseToTray, GetCurrentVersion, CheckForUpdate, InstallUpdate } from "../../wailsjs/go/main/App";
   import { EventsOn } from "../../wailsjs/runtime/runtime";
 
   const dispatch = createEventDispatcher<{ close: void }>();
 
   let autostartEnabled = false;
   let autostartLoading = true;
+  let closeToTray = true;
+  let closeToTrayLoading = true;
 
   let currentVersion = "";
   let updateInfo: { latestVersion: string; releaseUrl: string; assetUrl: string; releaseNotes: string } | null = null;
@@ -22,6 +24,14 @@
       console.error("Failed to get autostart status:", e);
     } finally {
       autostartLoading = false;
+    }
+
+    try {
+      closeToTray = await GetCloseToTray();
+    } catch (e) {
+      console.error("Failed to get close-to-tray setting:", e);
+    } finally {
+      closeToTrayLoading = false;
     }
 
     try {
@@ -46,6 +56,16 @@
       autostartEnabled = newValue;
     } catch (e: any) {
       console.error("Failed to set autostart:", e);
+    }
+  }
+
+  async function toggleCloseToTray() {
+    const newValue = !closeToTray;
+    try {
+      await SetCloseToTray(newValue);
+      closeToTray = newValue;
+    } catch (e: any) {
+      console.error("Failed to set close-to-tray:", e);
     }
   }
 
@@ -95,6 +115,20 @@
             {#if autostartEnabled}<span class="check-mark">■</span>{:else}<span class="check-empty">□</span>{/if}
           </span>
           <span class="checkbox-text" class:active={autostartEnabled}>start on login</span>
+        </label>
+      {/if}
+    </div>
+
+    <div class="settings-section">
+      <div class="section-label">window</div>
+      {#if closeToTrayLoading}
+        <div class="loading-text">// loading...</div>
+      {:else}
+        <label class="checkbox-label" on:click|preventDefault={toggleCloseToTray}>
+          <span class="hacker-check" class:checked={closeToTray}>
+            {#if closeToTray}<span class="check-mark">■</span>{:else}<span class="check-empty">□</span>{/if}
+          </span>
+          <span class="checkbox-text" class:active={closeToTray}>hide to tray on close</span>
         </label>
       {/if}
     </div>

--- a/frontend/wailsjs/go/main/App.d.ts
+++ b/frontend/wailsjs/go/main/App.d.ts
@@ -53,3 +53,7 @@ export function SubmitPassphrase(arg1:string):Promise<void>;
 export function TerminalWrite(arg1:string,arg2:string):Promise<void>;
 
 export function UpdateTunnel(arg1:config.TunnelConfig):Promise<void>;
+
+export function GetCloseToTray():Promise<boolean>;
+
+export function SetCloseToTray(arg1:boolean):Promise<void>;

--- a/frontend/wailsjs/go/main/App.js
+++ b/frontend/wailsjs/go/main/App.js
@@ -101,3 +101,11 @@ export function TerminalWrite(arg1, arg2) {
 export function UpdateTunnel(arg1) {
   return window['go']['main']['App']['UpdateTunnel'](arg1);
 }
+
+export function GetCloseToTray() {
+  return window['go']['main']['App']['GetCloseToTray']();
+}
+
+export function SetCloseToTray(arg1) {
+  return window['go']['main']['App']['SetCloseToTray'](arg1);
+}

--- a/internal/prefs/prefs.go
+++ b/internal/prefs/prefs.go
@@ -1,0 +1,94 @@
+// Package prefs manages application-level preferences stored separately
+// from the SSH config (which holds tunnel configs).
+package prefs
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"sync"
+)
+
+// Prefs holds user-configurable application preferences.
+type Prefs struct {
+	CloseToTray bool `json:"closeToTray"`
+}
+
+// defaultPrefs returns a Prefs with sensible defaults.
+func defaultPrefs() Prefs {
+	return Prefs{
+		CloseToTray: true,
+	}
+}
+
+// Store manages reading and writing of application preferences.
+type Store struct {
+	mu       sync.RWMutex
+	prefs    Prefs
+	filePath string
+}
+
+// NewStore creates a prefs Store backed by the default path
+// (~/.config/ssh-tunnel-manager/prefs.json).
+func NewStore() (*Store, error) {
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return nil, fmt.Errorf("getting home dir: %w", err)
+	}
+	path := filepath.Join(home, ".config", "ssh-tunnel-manager", "prefs.json")
+	return NewStoreWithPath(path)
+}
+
+// NewStoreWithPath creates a prefs Store backed by the given path.
+func NewStoreWithPath(path string) (*Store, error) {
+	s := &Store{filePath: path, prefs: defaultPrefs()}
+	if err := s.load(); err != nil {
+		return nil, err
+	}
+	return s, nil
+}
+
+// Get returns a copy of the current preferences.
+func (s *Store) Get() Prefs {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	return s.prefs
+}
+
+// Set replaces preferences and persists them to disk.
+func (s *Store) Set(p Prefs) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.prefs = p
+	return s.save()
+}
+
+func (s *Store) load() error {
+	data, err := os.ReadFile(s.filePath)
+	if os.IsNotExist(err) {
+		// First run — use defaults, no error.
+		return nil
+	}
+	if err != nil {
+		return fmt.Errorf("reading prefs: %w", err)
+	}
+	if err := json.Unmarshal(data, &s.prefs); err != nil {
+		return fmt.Errorf("parsing prefs: %w", err)
+	}
+	return nil
+}
+
+func (s *Store) save() error {
+	if err := os.MkdirAll(filepath.Dir(s.filePath), 0o700); err != nil {
+		return fmt.Errorf("creating prefs dir: %w", err)
+	}
+	data, err := json.MarshalIndent(s.prefs, "", "  ")
+	if err != nil {
+		return fmt.Errorf("marshalling prefs: %w", err)
+	}
+	if err := os.WriteFile(s.filePath, data, 0o600); err != nil {
+		return fmt.Errorf("writing prefs: %w", err)
+	}
+	return nil
+}

--- a/main.go
+++ b/main.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"context"
 	"embed"
 	"log/slog"
 	"os"
@@ -8,8 +9,10 @@ import (
 	"github.com/wailsapp/wails/v2"
 	"github.com/wailsapp/wails/v2/pkg/options"
 	"github.com/wailsapp/wails/v2/pkg/options/assetserver"
+	"github.com/wailsapp/wails/v2/pkg/runtime"
 
 	"ssh-tunnel-manager/internal/config"
+	"ssh-tunnel-manager/internal/prefs"
 )
 
 //go:embed all:frontend/dist
@@ -33,7 +36,13 @@ func main() {
 		os.Exit(1)
 	}
 
-	app := NewApp(store, startHidden)
+	prefsStore, err := prefs.NewStore()
+	if err != nil {
+		slog.Error("failed to initialize prefs store", "error", err)
+		os.Exit(1)
+	}
+
+	app := NewApp(store, prefsStore, startHidden)
 
 	err = wails.Run(&options.App{
 		Title:     "SSH Tunnel Manager",
@@ -43,10 +52,16 @@ func main() {
 		AssetServer: &assetserver.Options{
 			Assets: assets,
 		},
-		BackgroundColour:  &options.RGBA{R: 10, G: 10, B: 10, A: 1},
-		HideWindowOnClose: true,
-		OnStartup:         app.startup,
-		OnShutdown:        app.shutdown,
+		BackgroundColour: &options.RGBA{R: 10, G: 10, B: 10, A: 1},
+		OnBeforeClose: func(ctx context.Context) bool {
+			if app.GetCloseToTray() {
+				runtime.WindowHide(ctx)
+				return true // cancel the close — hide instead
+			}
+			return false // allow quit
+		},
+		OnStartup:  app.startup,
+		OnShutdown: app.shutdown,
 		Bind: []interface{}{
 			app,
 		},


### PR DESCRIPTION
Closes #8

## Changes
- New `internal/prefs` package — JSON-backed store for app-level settings (`~/.config/ssh-tunnel-manager/prefs.json`)
- `GetCloseToTray` / `SetCloseToTray` methods on App
- `OnBeforeClose` hook in `main.go` — hides window or quits based on the setting (replaces hardcoded `HideWindowOnClose: true`)
- Settings panel: new "window" section with "hide to tray on close" toggle
- Wails bindings updated (App.js, App.d.ts)

Default: hide to tray (preserves existing behaviour).