### PR TITLE
feat: pinned hosts, unified label colors, auto-connect toggle style

### DIFF
--- a/app.go
+++ b/app.go
@@ -135,6 +135,17 @@ func (a *App) GetConfigFiles() []string {
 	return files
 }
 
+// GetIncludedConfigFiles lists the files that can be written to when Include
+// directives are present in the main config.
+func (a *App) GetIncludedConfigFiles() []config.ConfigFileInfo {
+	files, err := a.store.GetIncludedConfigFiles()
+	if err != nil {
+		slog.Warn("failed to list included config files", "error", err)
+		return nil
+	}
+	return files
+}
+
 // AddTunnel persists a new tunnel configuration. ID is set to Name.
 func (a *App) AddTunnel(t config.TunnelConfig) error {
 	t.ID = t.Name
@@ -488,19 +499,20 @@ func (a *App) ExportTunnels(path string, ids []string) error {
 
 func entryToTunnel(e sshconfig.HostEntry) config.TunnelConfig {
 	t := config.TunnelConfig{
-		ID:           e.Alias,
-		Name:         e.Alias,
-		Host:         e.HostName,
-		Port:         e.Port,
-		User:         e.User,
-		KeyPath:      e.IdentityFile,
-		ProxyCommand: e.ProxyCommand,
-		ProxyJump:    e.ProxyJump,
-		Color:        e.Color,
-		Group:        e.Group,
-		AutoConnect:  e.AutoConnect,
-		Pinned:       e.Pinned,
-		SourceFile:   e.SourceFile,
+		ID:              e.Alias,
+		Name:            e.Alias,
+		Host:            e.HostName,
+		Port:            e.Port,
+		User:            e.User,
+		KeyPath:         e.IdentityFile,
+		ProxyCommand:    e.ProxyCommand,
+		ProxyJump:       e.ProxyJump,
+		Color:           e.Color,
+		Group:           e.Group,
+		AutoConnect:     e.AutoConnect,
+		Pinned:          e.Pinned,
+		SourceFile:      e.SourceFile,
+		SourceFileLabel: sshconfig.CollapseTildePath(e.SourceFile),
 	}
 	for _, pf := range e.PortForwards {
 		t.PortForwards = append(t.PortForwards, config.PortForward{

--- a/app.go
+++ b/app.go
@@ -559,6 +559,62 @@ func (a *App) ClearTunnelLogs(tunnelID string) {
 	delete(a.logBuf, tunnelID)
 }
 
+// ConnectGroup connects all tunnels belonging to the given group.
+func (a *App) ConnectGroup(group string) error {
+	tunnels := a.store.GetTunnels()
+	var firstErr error
+	for _, t := range tunnels {
+		if t.Group != group {
+			continue
+		}
+		if err := a.manager.Connect(t); err != nil && firstErr == nil {
+			firstErr = err
+		}
+	}
+	return firstErr
+}
+
+// DisconnectGroup disconnects all tunnels belonging to the given group.
+func (a *App) DisconnectGroup(group string) error {
+	tunnels := a.store.GetTunnels()
+	var firstErr error
+	for _, t := range tunnels {
+		if t.Group != group {
+			continue
+		}
+		if err := a.manager.Disconnect(t.ID); err != nil && firstErr == nil {
+			firstErr = err
+		}
+	}
+	return firstErr
+}
+
+// RenameGroup renames a group across all tunnels that belong to it.
+func (a *App) RenameGroup(oldName, newName string) error {
+	newName = strings.TrimSpace(newName)
+	if newName == "" {
+		return fmt.Errorf("new group name cannot be empty")
+	}
+	if oldName == newName {
+		return nil
+	}
+	tunnels := a.store.GetTunnels()
+	for _, t := range tunnels {
+		if t.Group != oldName {
+			continue
+		}
+		t.Group = newName
+		if err := a.store.UpdateTunnel(t); err != nil {
+			return fmt.Errorf("renaming group for %s: %w", t.Name, err)
+		}
+	}
+	a.tray.RefreshMenu()
+	if a.ctx != nil {
+		runtime.EventsEmit(a.ctx, "tunnels:changed")
+	}
+	return nil
+}
+
 type tunnelNotFoundError struct {
 	id string
 }

--- a/app.go
+++ b/app.go
@@ -169,6 +169,20 @@ func (a *App) DeleteTunnel(id string) error {
 	return nil
 }
 
+// SetTunnelPinned toggles the pinned state of a tunnel and persists it.
+func (a *App) SetTunnelPinned(id string, pinned bool) error {
+	t, ok := a.store.GetTunnel(id)
+	if !ok {
+		return &tunnelNotFoundError{id}
+	}
+	t.Pinned = pinned
+	if err := a.store.UpdateTunnel(t); err != nil {
+		return err
+	}
+	a.tray.RefreshMenu()
+	return nil
+}
+
 // ConnectTunnel starts an SSH connection for the given tunnel ID.
 func (a *App) ConnectTunnel(id string) error {
 	cfg, ok := a.store.GetTunnel(id)
@@ -485,6 +499,7 @@ func entryToTunnel(e sshconfig.HostEntry) config.TunnelConfig {
 		Color:        e.Color,
 		Group:        e.Group,
 		AutoConnect:  e.AutoConnect,
+		Pinned:       e.Pinned,
 		SourceFile:   e.SourceFile,
 	}
 	for _, pf := range e.PortForwards {
@@ -510,6 +525,7 @@ func tunnelToEntry(t config.TunnelConfig) sshconfig.HostEntry {
 		Color:        t.Color,
 		Group:        t.Group,
 		AutoConnect:  t.AutoConnect,
+		Pinned:       t.Pinned,
 		SourceFile:   t.SourceFile,
 	}
 	for _, pf := range t.PortForwards {

--- a/frontend/src/App.svelte
+++ b/frontend/src/App.svelte
@@ -77,7 +77,7 @@
       {#if showImport}
         <ImportDialog on:close={() => (showImport = false)} />
       {:else}
-        <TunnelList filterGroup={selectedGroup} />
+        <TunnelList filterGroup={selectedGroup} on:groupRenamed={(e) => selectedGroup = e.detail} />
       {/if}
     </main>
   </div>

--- a/frontend/src/components/GroupSidebar.svelte
+++ b/frontend/src/components/GroupSidebar.svelte
@@ -130,21 +130,6 @@
       </button>
     {/if}
 
-    {#if groups.ungroupedTotal > 0}
-      <button
-        class="sidebar-item"
-        class:active={selectedGroup === "__ungrouped__"}
-        on:click={() => selectGroup("__ungrouped__")}
-      >
-        <span class="item-icon">~</span>
-        <span class="item-name">ungrouped</span>
-        <span class="item-count">{groups.ungroupedTotal}</span>
-        {#if groups.ungroupedConnected > 0}
-          <span class="item-dot active-dot"></span>
-        {/if}
-      </button>
-    {/if}
-
     {#each groups.groups as group (group.name)}
       <div class="sidebar-group-wrapper">
         {#if renamingGroup === group.name}
@@ -183,6 +168,21 @@
         {/if}
       </div>
     {/each}
+
+    {#if groups.ungroupedTotal > 0}
+      <button
+        class="sidebar-item"
+        class:active={selectedGroup === "__ungrouped__"}
+        on:click={() => selectGroup("__ungrouped__")}
+      >
+        <span class="item-icon">~</span>
+        <span class="item-name">nieprzypisane</span>
+        <span class="item-count">{groups.ungroupedTotal}</span>
+        {#if groups.ungroupedConnected > 0}
+          <span class="item-dot active-dot"></span>
+        {/if}
+      </button>
+    {/if}
   </div>
 </div>
 

--- a/frontend/src/components/GroupSidebar.svelte
+++ b/frontend/src/components/GroupSidebar.svelte
@@ -14,10 +14,17 @@
     const groupMap = new Map<string, { total: number; connected: number }>();
     let ungroupedTotal = 0;
     let ungroupedConnected = 0;
+    let pinnedTotal = 0;
+    let pinnedConnected = 0;
 
     for (const t of $tunnels) {
       const status = getStatus($statuses, t.id);
       const isConnected = status === "connected" || status === "connecting" || status === "reconnecting";
+
+      if (t.pinned) {
+        pinnedTotal++;
+        if (isConnected) pinnedConnected++;
+      }
 
       if (t.group) {
         const existing = groupMap.get(t.group);
@@ -38,7 +45,7 @@
       result.push({ name, count: info.total, connectedCount: info.connected });
     }
     result.sort((a, b) => a.name.localeCompare(b.name));
-    return { groups: result, ungroupedTotal, ungroupedConnected };
+    return { groups: result, ungroupedTotal, ungroupedConnected, pinnedTotal, pinnedConnected };
   })();
 
   $: totalConnected = (() => {
@@ -71,6 +78,21 @@
         <span class="item-dot active-dot"></span>
       {/if}
     </button>
+
+    {#if groups.pinnedTotal > 0}
+      <button
+        class="sidebar-item"
+        class:active={selectedGroup === "__pinned__"}
+        on:click={() => selectGroup("__pinned__")}
+      >
+        <span class="item-icon">^</span>
+        <span class="item-name">przypięte</span>
+        <span class="item-count">{groups.pinnedTotal}</span>
+        {#if groups.pinnedConnected > 0}
+          <span class="item-dot active-dot"></span>
+        {/if}
+      </button>
+    {/if}
 
     {#if groups.ungroupedTotal > 0}
       <button
@@ -185,7 +207,7 @@
 
   .item-count {
     font-size: 9px;
-    color: #444;
+    color: var(--muted);
     flex-shrink: 0;
   }
 

--- a/frontend/src/components/GroupSidebar.svelte
+++ b/frontend/src/components/GroupSidebar.svelte
@@ -155,16 +155,7 @@
               <span class="item-dot active-dot"></span>
             {/if}
           </button>
-          {#if selectedGroup === group.name}
-            <div class="group-actions">
-              {#if isGroupAllConnected(group.name)}
-                <button class="group-act-btn disconnect" on:click={() => disconnectGroup(group.name)} title="Disconnect all">disconnect</button>
-              {:else}
-                <button class="group-act-btn" on:click={() => connectGroup(group.name)} title="Connect all">connect</button>
-              {/if}
-              <button class="group-act-btn" on:click|stopPropagation={() => startRename(group.name)} title="Rename group">✎</button>
-            </div>
-          {/if}
+
         {/if}
       </div>
     {/each}
@@ -292,34 +283,6 @@
     flex-direction: column;
   }
 
-  .group-actions {
-    display: flex;
-    gap: 4px;
-    padding: 2px 12px 4px 28px;
-  }
-
-  .group-act-btn {
-    background: transparent;
-    border: 1px solid var(--border);
-    color: var(--muted);
-    font-family: 'JetBrains Mono', monospace;
-    font-size: 8px;
-    padding: 1px 5px;
-    cursor: pointer;
-    border-radius: 2px;
-    transition: color 0.15s, border-color 0.15s;
-    letter-spacing: 0.05em;
-  }
-
-  .group-act-btn:hover {
-    color: var(--accent);
-    border-color: var(--accent);
-  }
-
-  .group-act-btn.disconnect:hover {
-    color: #ff4444;
-    border-color: #ff4444;
-  }
 
   .rename-row {
     padding: 4px 12px;

--- a/frontend/src/components/GroupSidebar.svelte
+++ b/frontend/src/components/GroupSidebar.svelte
@@ -1,8 +1,10 @@
 <script lang="ts">
-  import { tunnels, statuses, getStatus } from "../stores/tunnels";
+  import { tunnels, statuses, getStatus, connectGroup, disconnectGroup, renameGroup } from "../stores/tunnels";
   import type { TunnelStatus } from "../types";
 
   export let selectedGroup: string | null = null;
+  let renamingGroup: string | null = null;
+  let renameValue = "";
 
   interface GroupInfo {
     name: string;
@@ -59,6 +61,40 @@
 
   function selectGroup(group: string | null) {
     selectedGroup = group;
+    renamingGroup = null;
+  }
+
+  function startRename(groupName: string) {
+    renamingGroup = groupName;
+    renameValue = groupName;
+  }
+
+  async function confirmRename() {
+    if (!renamingGroup || !renameValue.trim()) {
+      renamingGroup = null;
+      return;
+    }
+    const oldName = renamingGroup;
+    const newName = renameValue.trim();
+    renamingGroup = null;
+    if (oldName === newName) return;
+    await renameGroup(oldName, newName);
+    if (selectedGroup === oldName) {
+      selectedGroup = newName;
+    }
+  }
+
+  function handleRenameKeydown(e: KeyboardEvent) {
+    if (e.key === "Enter") confirmRename();
+    if (e.key === "Escape") renamingGroup = null;
+  }
+
+  function isGroupAllConnected(groupName: string): boolean {
+    const groupTunnels = $tunnels.filter(t => t.group === groupName);
+    return groupTunnels.length > 0 && groupTunnels.every(t => {
+      const s = getStatus($statuses, t.id);
+      return s === "connected" || s === "connecting" || s === "reconnecting";
+    });
   }
 </script>
 
@@ -110,18 +146,42 @@
     {/if}
 
     {#each groups.groups as group (group.name)}
-      <button
-        class="sidebar-item"
-        class:active={selectedGroup === group.name}
-        on:click={() => selectGroup(group.name)}
-      >
-        <span class="item-icon">▸</span>
-        <span class="item-name">{group.name}</span>
-        <span class="item-count">{group.count}</span>
-        {#if group.connectedCount > 0}
-          <span class="item-dot active-dot"></span>
+      <div class="sidebar-group-wrapper">
+        {#if renamingGroup === group.name}
+          <div class="rename-row">
+            <input
+              class="rename-input"
+              bind:value={renameValue}
+              on:keydown={handleRenameKeydown}
+              on:blur={confirmRename}
+              autofocus
+            />
+          </div>
+        {:else}
+          <button
+            class="sidebar-item"
+            class:active={selectedGroup === group.name}
+            on:click={() => selectGroup(group.name)}
+          >
+            <span class="item-icon">▸</span>
+            <span class="item-name">{group.name}</span>
+            <span class="item-count">{group.count}</span>
+            {#if group.connectedCount > 0}
+              <span class="item-dot active-dot"></span>
+            {/if}
+          </button>
+          {#if selectedGroup === group.name}
+            <div class="group-actions">
+              {#if isGroupAllConnected(group.name)}
+                <button class="group-act-btn disconnect" on:click={() => disconnectGroup(group.name)} title="Rozłącz wszystkie">rozłącz</button>
+              {:else}
+                <button class="group-act-btn" on:click={() => connectGroup(group.name)} title="Połącz wszystkie">połącz</button>
+              {/if}
+              <button class="group-act-btn" on:click|stopPropagation={() => startRename(group.name)} title="Zmień nazwę grupy">✎</button>
+            </div>
+          {/if}
         {/if}
-      </button>
+      </div>
     {/each}
   </div>
 </div>
@@ -225,5 +285,55 @@
   .active-dot {
     background: var(--accent);
     box-shadow: 0 0 4px var(--accent);
+  }
+
+  .sidebar-group-wrapper {
+    display: flex;
+    flex-direction: column;
+  }
+
+  .group-actions {
+    display: flex;
+    gap: 4px;
+    padding: 2px 12px 4px 28px;
+  }
+
+  .group-act-btn {
+    background: transparent;
+    border: 1px solid var(--border);
+    color: var(--muted);
+    font-family: 'JetBrains Mono', monospace;
+    font-size: 8px;
+    padding: 1px 5px;
+    cursor: pointer;
+    border-radius: 2px;
+    transition: color 0.15s, border-color 0.15s;
+    letter-spacing: 0.05em;
+  }
+
+  .group-act-btn:hover {
+    color: var(--accent);
+    border-color: var(--accent);
+  }
+
+  .group-act-btn.disconnect:hover {
+    color: #ff4444;
+    border-color: #ff4444;
+  }
+
+  .rename-row {
+    padding: 4px 12px;
+  }
+
+  .rename-input {
+    width: 100%;
+    background: var(--surface2);
+    border: 1px solid var(--accent);
+    border-radius: 2px;
+    color: var(--text);
+    font-family: 'JetBrains Mono', monospace;
+    font-size: 10px;
+    padding: 3px 6px;
+    outline: none;
   }
 </style>

--- a/frontend/src/components/GroupSidebar.svelte
+++ b/frontend/src/components/GroupSidebar.svelte
@@ -122,7 +122,7 @@
         on:click={() => selectGroup("__pinned__")}
       >
         <span class="item-icon">^</span>
-        <span class="item-name">przypięte</span>
+        <span class="item-name">pinned</span>
         <span class="item-count">{groups.pinnedTotal}</span>
         {#if groups.pinnedConnected > 0}
           <span class="item-dot active-dot"></span>
@@ -158,11 +158,11 @@
           {#if selectedGroup === group.name}
             <div class="group-actions">
               {#if isGroupAllConnected(group.name)}
-                <button class="group-act-btn disconnect" on:click={() => disconnectGroup(group.name)} title="Rozłącz wszystkie">rozłącz</button>
+                <button class="group-act-btn disconnect" on:click={() => disconnectGroup(group.name)} title="Disconnect all">disconnect</button>
               {:else}
-                <button class="group-act-btn" on:click={() => connectGroup(group.name)} title="Połącz wszystkie">połącz</button>
+                <button class="group-act-btn" on:click={() => connectGroup(group.name)} title="Connect all">connect</button>
               {/if}
-              <button class="group-act-btn" on:click|stopPropagation={() => startRename(group.name)} title="Zmień nazwę grupy">✎</button>
+              <button class="group-act-btn" on:click|stopPropagation={() => startRename(group.name)} title="Rename group">✎</button>
             </div>
           {/if}
         {/if}
@@ -176,7 +176,7 @@
         on:click={() => selectGroup("__ungrouped__")}
       >
         <span class="item-icon">~</span>
-        <span class="item-name">nieprzypisane</span>
+        <span class="item-name">unassigned</span>
         <span class="item-count">{groups.ungroupedTotal}</span>
         {#if groups.ungroupedConnected > 0}
           <span class="item-dot active-dot"></span>

--- a/frontend/src/components/TunnelCard.svelte
+++ b/frontend/src/components/TunnelCard.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
   import type { TunnelConfig, TunnelStatus } from "../types";
-  import { connectTunnel, disconnectTunnel, deleteTunnel } from "../stores/tunnels";
+  import { connectTunnel, disconnectTunnel, deleteTunnel, setTunnelPinned } from "../stores/tunnels";
   import StatusBadge from "./StatusBadge.svelte";
   import { createEventDispatcher } from "svelte";
 
@@ -36,6 +36,10 @@
   async function handleDelete() {
     if (!confirm(`Delete tunnel "${tunnel.name}"?`)) return;
     await deleteTunnel(tunnel.id);
+  }
+
+  async function handleTogglePin() {
+    await setTunnelPinned(tunnel.id, !tunnel.pinned);
   }
 
   $: isActive = status === "connected" || status === "connecting" || status === "reconnecting";
@@ -87,6 +91,12 @@
           connect
         </button>
       {/if}
+      <button
+        class="action-btn pin"
+        class:pinned={tunnel.pinned}
+        on:click={handleTogglePin}
+        title={tunnel.pinned ? "Odepnij" : "Przypnij"}
+      >{tunnel.pinned ? "unpin" : "pin"}</button>
       <button class="action-btn secondary" on:click={() => dispatch("logs", tunnel)}>logs</button>
       <button class="action-btn secondary" on:click={() => dispatch("terminal", tunnel)}>term</button>
       <button class="action-btn secondary" on:click={() => dispatch("edit", tunnel)}>edit</button>
@@ -229,5 +239,20 @@
   .action-btn.danger:hover:not(:disabled) {
     color: #ff4444;
     border-color: #ff4444;
+  }
+
+  .action-btn.pin {
+    color: var(--muted);
+    border-color: var(--border);
+  }
+
+  .action-btn.pin:hover:not(:disabled) {
+    color: var(--accent2);
+    border-color: var(--accent2);
+  }
+
+  .action-btn.pin.pinned {
+    color: var(--accent2);
+    border-color: var(--accent2);
   }
 </style>

--- a/frontend/src/components/TunnelCard.svelte
+++ b/frontend/src/components/TunnelCard.svelte
@@ -122,10 +122,6 @@
     transition: border-color 0.15s;
   }
 
-  .tunnel-card[data-has-color="true"] {
-    border-left-color: var(--tunnel-tint);
-  }
-
   .tunnel-card[data-has-color="true"]::after {
     content: "";
     position: absolute;

--- a/frontend/src/components/TunnelCard.svelte
+++ b/frontend/src/components/TunnelCard.svelte
@@ -51,17 +51,21 @@
   class="tunnel-card"
   class:connected={isConnected}
   class:error={isError}
+  data-has-color={tunnel.color ? "true" : undefined}
+  style={tunnel.color ? `--tunnel-tint: ${tunnel.color};` : undefined}
 >
   <div class="card-header">
     <div class="card-info">
       <div class="card-name-row">
-        {#if tunnel.color}
-          <span class="color-dot" style="color: {tunnel.color};">●</span>
-        {/if}
         <span class="card-name">{tunnel.name}</span>
         <StatusBadge {status} />
       </div>
       <div class="card-host">{tunnel.user}@{tunnel.host}:{tunnel.port}</div>
+      {#if tunnel.sourceFileLabel || tunnel.sourceFile}
+        <div class="card-source">
+          plik config: {tunnel.sourceFileLabel ?? tunnel.sourceFile}
+        </div>
+      {/if}
       {#if tunnel.portForwards && tunnel.portForwards.length > 0}
         <div class="card-forwards">
           {#each tunnel.portForwards as pf}
@@ -107,12 +111,28 @@
 
 <style>
   .tunnel-card {
+    --tunnel-tint: var(--border);
+    position: relative;
+    overflow: hidden;
     background: var(--surface);
     border: 1px solid var(--border);
-    border-left: 2px solid var(--border);
+    border-left: 4px solid var(--border);
     padding: 10px 12px;
     border-radius: 2px;
     transition: border-color 0.15s;
+  }
+
+  .tunnel-card[data-has-color="true"] {
+    border-left-color: var(--tunnel-tint);
+  }
+
+  .tunnel-card[data-has-color="true"]::after {
+    content: "";
+    position: absolute;
+    inset: 0;
+    background: var(--tunnel-tint);
+    opacity: 0.06;
+    pointer-events: none;
   }
 
   .tunnel-card:hover {
@@ -135,11 +155,15 @@
     align-items: flex-start;
     justify-content: space-between;
     gap: 12px;
+    position: relative;
+    z-index: 1;
   }
 
   .card-info {
     min-width: 0;
     flex: 1;
+    position: relative;
+    z-index: 1;
   }
 
   .card-name-row {
@@ -149,15 +173,10 @@
     margin-bottom: 3px;
   }
 
-  .color-dot {
-    font-size: 8px;
-    flex-shrink: 0;
-  }
-
   .card-name {
     font-size: 12px;
     font-weight: 600;
-    color: #e0e0e0;
+    color: var(--accent);
     white-space: nowrap;
     overflow: hidden;
     text-overflow: ellipsis;
@@ -165,7 +184,14 @@
 
   .card-host {
     font-size: 10px;
-    color: var(--muted);
+    color: var(--accent);
+    font-family: 'JetBrains Mono', monospace;
+    margin-bottom: 4px;
+  }
+
+  .card-source {
+    font-size: 9px;
+    color: var(--accent);
     font-family: 'JetBrains Mono', monospace;
     margin-bottom: 4px;
   }
@@ -180,9 +206,9 @@
   .forward-tag {
     font-size: 9px;
     font-family: 'JetBrains Mono', monospace;
-    color: var(--muted);
-    background: var(--surface2);
-    border: 1px solid var(--border);
+    color: var(--accent);
+    background: rgba(0, 255, 136, 0.08);
+    border: 1px solid var(--accent);
     padding: 1px 5px;
     border-radius: 2px;
   }
@@ -192,6 +218,8 @@
     align-items: center;
     gap: 4px;
     flex-shrink: 0;
+    position: relative;
+    z-index: 1;
   }
 
   .action-btn {

--- a/frontend/src/components/TunnelCard.svelte
+++ b/frontend/src/components/TunnelCard.svelte
@@ -63,7 +63,7 @@
       <div class="card-host">{tunnel.user}@{tunnel.host}:{tunnel.port}</div>
       {#if tunnel.sourceFileLabel || tunnel.sourceFile}
         <div class="card-source">
-          plik config: {tunnel.sourceFileLabel ?? tunnel.sourceFile}
+          config file: {tunnel.sourceFileLabel ?? tunnel.sourceFile}
         </div>
       {/if}
       {#if tunnel.portForwards && tunnel.portForwards.length > 0}
@@ -176,7 +176,7 @@
   .card-name {
     font-size: 12px;
     font-weight: 600;
-    color: var(--accent);
+    color: var(--text);
     white-space: nowrap;
     overflow: hidden;
     text-overflow: ellipsis;
@@ -184,14 +184,14 @@
 
   .card-host {
     font-size: 10px;
-    color: var(--accent);
+    color: var(--text);
     font-family: 'JetBrains Mono', monospace;
     margin-bottom: 4px;
   }
 
   .card-source {
     font-size: 9px;
-    color: var(--accent);
+    color: var(--muted);
     font-family: 'JetBrains Mono', monospace;
     margin-bottom: 4px;
   }
@@ -206,9 +206,9 @@
   .forward-tag {
     font-size: 9px;
     font-family: 'JetBrains Mono', monospace;
-    color: var(--accent);
-    background: rgba(0, 255, 136, 0.08);
-    border: 1px solid var(--accent);
+    color: var(--text);
+    background: var(--surface2);
+    border: 1px solid var(--border);
     padding: 1px 5px;
     border-radius: 2px;
   }

--- a/frontend/src/components/TunnelForm.svelte
+++ b/frontend/src/components/TunnelForm.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
   import type { TunnelConfig, PortForward } from "../types";
-  import { addTunnel, updateTunnel } from "../stores/tunnels";
+  import { addTunnel, updateTunnel, tunnels } from "../stores/tunnels";
   import { createEventDispatcher } from "svelte";
 
   export let tunnel: TunnelConfig | null = null;
@@ -37,6 +37,8 @@
   let error = "";
 
   $: isEdit = tunnel !== null;
+
+  $: existingGroups = [...new Set($tunnels.map(t => t.group).filter(Boolean))].sort();
 
   function addPortForward() {
     portForwards = [...portForwards, { localPort: 0, remoteHost: "127.0.0.1", remotePort: 0, description: "" }];
@@ -120,7 +122,14 @@
           bind:value={group}
           class="field-input"
           placeholder="production"
+          list="group-options"
+          autocomplete="off"
         />
+        <datalist id="group-options">
+          {#each existingGroups as g}
+            <option value={g} />
+          {/each}
+        </datalist>
       </div>
     </div>
 

--- a/frontend/src/components/TunnelForm.svelte
+++ b/frontend/src/components/TunnelForm.svelte
@@ -76,6 +76,7 @@
         color: tunnelColor || undefined,
         group: group.trim(),
         autoConnect,
+        pinned: tunnel?.pinned,
       };
       if (isEdit) {
         await updateTunnel(cfg);
@@ -264,9 +265,11 @@
       {/if}
     </div>
 
-    <label class="checkbox-label">
-      <input type="checkbox" bind:checked={autoConnect} />
-      <span>auto-connect on startup</span>
+    <label class="checkbox-label" on:click|preventDefault={() => (autoConnect = !autoConnect)}>
+      <span class="hacker-check" class:checked={autoConnect}>
+        {#if autoConnect}<span class="check-mark">■</span>{:else}<span class="check-empty">□</span>{/if}
+      </span>
+      <span class="checkbox-text" class:active={autoConnect}>auto-connect on startup</span>
     </label>
 
     <div class="form-actions">
@@ -503,9 +506,48 @@
     align-items: center;
     gap: 8px;
     cursor: pointer;
-    font-size: 10px;
-    color: var(--muted);
+    font-size: 11px;
+    color: var(--text);
     font-family: 'JetBrains Mono', monospace;
+    user-select: none;
+    padding: 4px 0;
+  }
+
+  .hacker-check {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    width: 16px;
+    height: 16px;
+    font-size: 14px;
+    line-height: 1;
+    transition: all 0.15s;
+  }
+
+  .check-empty {
+    color: var(--muted);
+  }
+
+  .check-mark {
+    color: var(--accent);
+    text-shadow: 0 0 6px var(--accent);
+  }
+
+  .checkbox-text {
+    color: var(--muted);
+    transition: color 0.15s;
+  }
+
+  .checkbox-text.active {
+    color: var(--accent);
+  }
+
+  .checkbox-label:hover .check-empty {
+    color: var(--text);
+  }
+
+  .checkbox-label:hover .checkbox-text:not(.active) {
+    color: var(--text);
   }
 
   .form-actions {

--- a/frontend/src/components/TunnelForm.svelte
+++ b/frontend/src/components/TunnelForm.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
   import type { TunnelConfig, PortForward } from "../types";
-  import { addTunnel, updateTunnel, tunnels } from "../stores/tunnels";
+  import { addTunnel, updateTunnel, tunnels, includedConfigFiles } from "../stores/tunnels";
   import { createEventDispatcher } from "svelte";
 
   export let tunnel: TunnelConfig | null = null;
@@ -17,6 +17,8 @@
   let tunnelColor = tunnel?.color ?? "";
   let proxyCommand = tunnel?.proxyCommand ?? "";
   let proxyJump = tunnel?.proxyJump ?? "";
+  let selectedConfigFile = tunnel?.sourceFile ?? "";
+  let configSelectionKey = tunnel?.id ?? "__new";
 
   const presetColors = [
     { name: "red", hex: "#ef4444" },
@@ -32,11 +34,29 @@
     ? [...tunnel.portForwards]
     : [];
   let showAdvanced = !!(tunnel?.proxyCommand || tunnel?.proxyJump);
+  let hasIncludeOptions = false;
 
   let saving = false;
   let error = "";
 
   $: isEdit = tunnel !== null;
+  $: hasIncludeOptions = $includedConfigFiles.length > 1;
+
+  $: {
+    const key = tunnel?.id ?? "__new";
+    if (key !== configSelectionKey) {
+      configSelectionKey = key;
+      if (tunnel?.sourceFile) {
+        selectedConfigFile = tunnel.sourceFile;
+      } else {
+        selectedConfigFile = $includedConfigFiles[0]?.path ?? "";
+      }
+    }
+  }
+
+  $: if (!selectedConfigFile && !tunnel && hasIncludeOptions) {
+    selectedConfigFile = $includedConfigFiles[0]?.path ?? "";
+  }
 
   $: existingGroups = [...new Set($tunnels.map(t => t.group).filter(Boolean))].sort();
 
@@ -80,6 +100,9 @@
         autoConnect,
         pinned: tunnel?.pinned,
       };
+      if (hasIncludeOptions && selectedConfigFile) {
+        cfg.sourceFile = selectedConfigFile;
+      }
       if (isEdit) {
         await updateTunnel(cfg);
       } else {
@@ -198,6 +221,18 @@
         />
       </div>
     </div>
+
+    {#if hasIncludeOptions}
+      <div class="field">
+        <label class="field-label">plik config</label>
+        <select class="field-input" bind:value={selectedConfigFile}>
+          {#each $includedConfigFiles as file}
+            <option value={file.path}>{file.label}</option>
+          {/each}
+        </select>
+        <p class="hint">wybierz plik docelowy dla nowego hosta</p>
+      </div>
+    {/if}
 
     <div class="field">
       <div class="forwards-header">

--- a/frontend/src/components/TunnelForm.svelte
+++ b/frontend/src/components/TunnelForm.svelte
@@ -224,13 +224,13 @@
 
     {#if hasIncludeOptions}
       <div class="field">
-        <label class="field-label">plik config</label>
+        <label class="field-label">config file</label>
         <select class="field-input" bind:value={selectedConfigFile}>
           {#each $includedConfigFiles as file}
             <option value={file.path}>{file.label}</option>
           {/each}
         </select>
-        <p class="hint">wybierz plik docelowy dla nowego hosta</p>
+        <p class="hint">choose target config file for this host</p>
       </div>
     {/if}
 

--- a/frontend/src/components/TunnelList.svelte
+++ b/frontend/src/components/TunnelList.svelte
@@ -94,13 +94,19 @@
 
   $: filteredTunnels = (() => {
     if (filterGroup === null) return $tunnels;
+    if (filterGroup === "__pinned__") return $tunnels.filter(t => t.pinned);
     if (filterGroup === "__ungrouped__") return $tunnels.filter(t => !t.group);
     return $tunnels.filter(t => t.group === filterGroup);
   })();
 
+  $: pinnedTunnels = filterGroup === null ? $tunnels.filter(t => t.pinned) : [];
+  $: unpinnedTunnels = filterGroup === null
+    ? filteredTunnels.filter(t => !t.pinned)
+    : filteredTunnels;
+
   $: fileSections = (() => {
     const fileMap = new Map<string, TunnelConfig[]>();
-    for (const t of filteredTunnels) {
+    for (const t of unpinnedTunnels) {
       const key = t.sourceFile || "";
       const arr = fileMap.get(key);
       if (arr) {
@@ -160,6 +166,22 @@
       </div>
     {:else}
       <div class="cards">
+        {#if pinnedTunnels.length > 0}
+          <div class="pinned-section">
+            <div class="pinned-header">// przypięte</div>
+            <div class="pinned-tunnels">
+              {#each pinnedTunnels as tunnel (tunnel.id)}
+                <TunnelCard
+                  {tunnel}
+                  status={getStatus($statuses, tunnel.id)}
+                  on:edit={handleEdit}
+                  on:logs={handleLogs}
+                  on:terminal={handleTerminal}
+                />
+              {/each}
+            </div>
+          </div>
+        {/if}
         {#each fileSections as section (section.file)}
           {#if hasMultipleFiles}
             <div class="file-section">
@@ -383,15 +405,15 @@
 
   .group-name {
     letter-spacing: 0.1em;
-    color: #444;
-  }
-
-  .group-header:hover .group-name {
     color: var(--muted);
   }
 
+  .group-header:hover .group-name {
+    color: var(--text);
+  }
+
   .group-count {
-    color: #333;
+    color: var(--muted);
   }
 
   .group-tunnels {
@@ -401,5 +423,28 @@
     padding-left: 14px;
     border-left: 1px solid var(--border);
     margin-left: 4px;
+  }
+
+  .pinned-section {
+    display: flex;
+    flex-direction: column;
+    gap: 4px;
+    margin-bottom: 8px;
+  }
+
+  .pinned-header {
+    font-size: 9px;
+    color: var(--accent2);
+    font-family: 'JetBrains Mono', monospace;
+    text-transform: uppercase;
+    letter-spacing: 0.1em;
+    padding: 4px 0;
+    border-bottom: 1px solid var(--border);
+  }
+
+  .pinned-tunnels {
+    display: flex;
+    flex-direction: column;
+    gap: 4px;
   }
 </style>

--- a/frontend/src/components/TunnelList.svelte
+++ b/frontend/src/components/TunnelList.svelte
@@ -123,11 +123,12 @@
   })();
 
   $: hasMultipleFiles = fileSections.length > 1;
+  $: isAllView = filterGroup === null;
   $: showInlineGroupTitle = filterGroup !== null && filterGroup !== "__pinned__" && filterGroup !== "__ungrouped__";
   $: currentTitle = (() => {
     if (filterGroup === null) return "all tunnels";
-    if (filterGroup === "__pinned__") return "przypięte";
-    if (filterGroup === "__ungrouped__") return "nieprzypisane";
+    if (filterGroup === "__pinned__") return "pinned";
+    if (filterGroup === "__ungrouped__") return "unassigned";
     return filterGroup || "all tunnels";
   })();
 
@@ -191,7 +192,7 @@
       <div class="cards">
         {#if pinnedTunnels.length > 0}
           <div class="pinned-section">
-            <div class="pinned-header">// przypięte</div>
+            <div class="pinned-header">// pinned</div>
             <div class="pinned-tunnels">
               {#each pinnedTunnels as tunnel (tunnel.id)}
                 <TunnelCard
@@ -218,6 +219,9 @@
               </button>
               {#if !collapsedFiles[section.file]}
                 <div class="file-tunnels">
+                  {#if isAllView && section.grouped.groups.length > 0}
+                    <div class="section-subheader">// Groups</div>
+                  {/if}
                   {#each section.grouped.groups as group (group.name)}
                     <div class="group-section">
                       <div class="group-header-row">
@@ -227,9 +231,9 @@
                           <span class="group-count">({group.tunnels.length})</span>
                         </button>
                         {#if groupAllConnected(group.tunnels)}
-                          <button class="group-action-btn disconnect" on:click|stopPropagation={() => handleGroupDisconnect(group.name)}>rozłącz</button>
+                          <button class="group-action-btn disconnect" on:click|stopPropagation={() => handleGroupDisconnect(group.name)}>disconnect</button>
                         {:else}
-                          <button class="group-action-btn" on:click|stopPropagation={() => handleGroupConnect(group.name)}>połącz wszystkie</button>
+                          <button class="group-action-btn" on:click|stopPropagation={() => handleGroupConnect(group.name)}>connect all</button>
                         {/if}
                       </div>
                       {#if !collapsedGroups[group.name]}
@@ -247,6 +251,9 @@
                       {/if}
                     </div>
                   {/each}
+                  {#if isAllView && section.grouped.ungrouped.length > 0}
+                    <div class="section-subheader">// Unassigned</div>
+                  {/if}
                   {#each section.grouped.ungrouped as tunnel (tunnel.id)}
                     <TunnelCard
                       {tunnel}
@@ -260,6 +267,9 @@
               {/if}
             </div>
           {:else}
+            {#if isAllView && section.grouped.groups.length > 0}
+              <div class="section-subheader">// Groups</div>
+            {/if}
             {#each section.grouped.groups as group (group.name)}
               <div class="group-section">
                 <div class="group-header-row">
@@ -269,9 +279,9 @@
                     <span class="group-count">({group.tunnels.length})</span>
                   </button>
                   {#if groupAllConnected(group.tunnels)}
-                    <button class="group-action-btn disconnect" on:click|stopPropagation={() => handleGroupDisconnect(group.name)}>rozłącz</button>
+                    <button class="group-action-btn disconnect" on:click|stopPropagation={() => handleGroupDisconnect(group.name)}>disconnect</button>
                   {:else}
-                    <button class="group-action-btn" on:click|stopPropagation={() => handleGroupConnect(group.name)}>połącz wszystkie</button>
+                    <button class="group-action-btn" on:click|stopPropagation={() => handleGroupConnect(group.name)}>connect all</button>
                   {/if}
                 </div>
                 {#if !collapsedGroups[group.name]}
@@ -289,6 +299,9 @@
                 {/if}
               </div>
             {/each}
+            {#if isAllView && section.grouped.ungrouped.length > 0}
+              <div class="section-subheader">// Unassigned</div>
+            {/if}
             {#each section.grouped.ungrouped as tunnel (tunnel.id)}
               <TunnelCard
                 {tunnel}
@@ -325,11 +338,20 @@
     font-size: 11px;
     text-transform: uppercase;
     letter-spacing: 0.08em;
-    color: var(--accent);
+    color: var(--text);
   }
 
   .list-title.muted-title {
     color: var(--muted);
+  }
+
+  .section-subheader {
+    font-family: 'JetBrains Mono', monospace;
+    font-size: 9px;
+    text-transform: uppercase;
+    letter-spacing: 0.08em;
+    color: var(--muted);
+    padding: 6px 0 2px;
   }
 
   .add-btn {
@@ -486,7 +508,7 @@
 
   .group-name {
     letter-spacing: 0.1em;
-    color: var(--accent);
+    color: var(--muted);
   }
 
   .group-header:hover .group-name {

--- a/frontend/src/components/TunnelList.svelte
+++ b/frontend/src/components/TunnelList.svelte
@@ -123,6 +123,13 @@
   })();
 
   $: hasMultipleFiles = fileSections.length > 1;
+  $: showInlineGroupTitle = filterGroup !== null && filterGroup !== "__pinned__" && filterGroup !== "__ungrouped__";
+  $: currentTitle = (() => {
+    if (filterGroup === null) return "all tunnels";
+    if (filterGroup === "__pinned__") return "przypięte";
+    if (filterGroup === "__ungrouped__") return "nieprzypisane";
+    return filterGroup || "all tunnels";
+  })();
 
   function groupAllConnected(tunnelList: TunnelConfig[]): boolean {
     return tunnelList.length > 0 && tunnelList.every(t => {
@@ -157,6 +164,7 @@
     <TunnelForm tunnel={editingTunnel} on:close={handleFormClose} />
   {:else}
     <div class="list-header">
+      <div class="list-title" class:muted-title={!showInlineGroupTitle}>{currentTitle}</div>
       <button class="add-btn" on:click={handleAdd}>+ new tunnel</button>
     </div>
   {/if}
@@ -210,15 +218,6 @@
               </button>
               {#if !collapsedFiles[section.file]}
                 <div class="file-tunnels">
-                  {#each section.grouped.ungrouped as tunnel (tunnel.id)}
-                    <TunnelCard
-                      {tunnel}
-                      status={getStatus($statuses, tunnel.id)}
-                      on:edit={handleEdit}
-                      on:logs={handleLogs}
-                      on:terminal={handleTerminal}
-                    />
-                  {/each}
                   {#each section.grouped.groups as group (group.name)}
                     <div class="group-section">
                       <div class="group-header-row">
@@ -248,19 +247,19 @@
                       {/if}
                     </div>
                   {/each}
+                  {#each section.grouped.ungrouped as tunnel (tunnel.id)}
+                    <TunnelCard
+                      {tunnel}
+                      status={getStatus($statuses, tunnel.id)}
+                      on:edit={handleEdit}
+                      on:logs={handleLogs}
+                      on:terminal={handleTerminal}
+                    />
+                  {/each}
                 </div>
               {/if}
             </div>
           {:else}
-            {#each section.grouped.ungrouped as tunnel (tunnel.id)}
-              <TunnelCard
-                {tunnel}
-                status={getStatus($statuses, tunnel.id)}
-                on:edit={handleEdit}
-                on:logs={handleLogs}
-                on:terminal={handleTerminal}
-              />
-            {/each}
             {#each section.grouped.groups as group (group.name)}
               <div class="group-section">
                 <div class="group-header-row">
@@ -290,6 +289,15 @@
                 {/if}
               </div>
             {/each}
+            {#each section.grouped.ungrouped as tunnel (tunnel.id)}
+              <TunnelCard
+                {tunnel}
+                status={getStatus($statuses, tunnel.id)}
+                on:edit={handleEdit}
+                on:logs={handleLogs}
+                on:terminal={handleTerminal}
+              />
+            {/each}
           {/if}
         {/each}
       </div>
@@ -306,8 +314,22 @@
 
   .list-header {
     display: flex;
-    justify-content: flex-end;
+    justify-content: space-between;
+    align-items: center;
     margin-bottom: 4px;
+    gap: 8px;
+  }
+
+  .list-title {
+    font-family: 'JetBrains Mono', monospace;
+    font-size: 11px;
+    text-transform: uppercase;
+    letter-spacing: 0.08em;
+    color: var(--accent);
+  }
+
+  .list-title.muted-title {
+    color: var(--muted);
   }
 
   .add-btn {
@@ -464,7 +486,7 @@
 
   .group-name {
     letter-spacing: 0.1em;
-    color: var(--muted);
+    color: var(--accent);
   }
 
   .group-header:hover .group-name {

--- a/frontend/src/components/TunnelList.svelte
+++ b/frontend/src/components/TunnelList.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
   import type { TunnelConfig } from "../types";
-  import { tunnels, statuses, loading, getStatus } from "../stores/tunnels";
+  import { tunnels, statuses, loading, getStatus, connectGroup, disconnectGroup } from "../stores/tunnels";
   import TunnelCard from "./TunnelCard.svelte";
   import TunnelForm from "./TunnelForm.svelte";
   import TunnelLogs from "./TunnelLogs.svelte";
@@ -123,6 +123,21 @@
   })();
 
   $: hasMultipleFiles = fileSections.length > 1;
+
+  function groupAllConnected(tunnelList: TunnelConfig[]): boolean {
+    return tunnelList.length > 0 && tunnelList.every(t => {
+      const s = getStatus($statuses, t.id);
+      return s === "connected" || s === "connecting" || s === "reconnecting";
+    });
+  }
+
+  function handleGroupConnect(groupName: string) {
+    connectGroup(groupName);
+  }
+
+  function handleGroupDisconnect(groupName: string) {
+    disconnectGroup(groupName);
+  }
 </script>
 
 {#if loggingTunnel}
@@ -206,11 +221,18 @@
                   {/each}
                   {#each section.grouped.groups as group (group.name)}
                     <div class="group-section">
-                      <button class="group-header" on:click={() => toggleGroup(group.name)}>
-                        <span class="group-arrow">{collapsedGroups[group.name] ? '▸' : '▾'}</span>
-                        <span class="group-name">{group.name.toUpperCase()}</span>
-                        <span class="group-count">({group.tunnels.length})</span>
-                      </button>
+                      <div class="group-header-row">
+                        <button class="group-header" on:click={() => toggleGroup(group.name)}>
+                          <span class="group-arrow">{collapsedGroups[group.name] ? '▸' : '▾'}</span>
+                          <span class="group-name">{group.name.toUpperCase()}</span>
+                          <span class="group-count">({group.tunnels.length})</span>
+                        </button>
+                        {#if groupAllConnected(group.tunnels)}
+                          <button class="group-action-btn disconnect" on:click|stopPropagation={() => handleGroupDisconnect(group.name)}>rozłącz</button>
+                        {:else}
+                          <button class="group-action-btn" on:click|stopPropagation={() => handleGroupConnect(group.name)}>połącz wszystkie</button>
+                        {/if}
+                      </div>
                       {#if !collapsedGroups[group.name]}
                         <div class="group-tunnels">
                           {#each group.tunnels as tunnel (tunnel.id)}
@@ -241,11 +263,18 @@
             {/each}
             {#each section.grouped.groups as group (group.name)}
               <div class="group-section">
-                <button class="group-header" on:click={() => toggleGroup(group.name)}>
-                  <span class="group-arrow">{collapsedGroups[group.name] ? '▸' : '▾'}</span>
-                  <span class="group-name">{group.name.toUpperCase()}</span>
-                  <span class="group-count">({group.tunnels.length})</span>
-                </button>
+                <div class="group-header-row">
+                  <button class="group-header" on:click={() => toggleGroup(group.name)}>
+                    <span class="group-arrow">{collapsedGroups[group.name] ? '▸' : '▾'}</span>
+                    <span class="group-name">{group.name.toUpperCase()}</span>
+                    <span class="group-count">({group.tunnels.length})</span>
+                  </button>
+                  {#if groupAllConnected(group.tunnels)}
+                    <button class="group-action-btn disconnect" on:click|stopPropagation={() => handleGroupDisconnect(group.name)}>rozłącz</button>
+                  {:else}
+                    <button class="group-action-btn" on:click|stopPropagation={() => handleGroupConnect(group.name)}>połącz wszystkie</button>
+                  {/if}
+                </div>
                 {#if !collapsedGroups[group.name]}
                   <div class="group-tunnels">
                     {#each group.tunnels as tunnel (tunnel.id)}
@@ -384,6 +413,12 @@
     gap: 4px;
   }
 
+  .group-header-row {
+    display: flex;
+    align-items: center;
+    gap: 6px;
+  }
+
   .group-header {
     display: flex;
     align-items: center;
@@ -396,6 +431,30 @@
     font-family: 'JetBrains Mono', monospace;
     font-size: 9px;
     text-align: left;
+  }
+
+  .group-action-btn {
+    background: transparent;
+    border: 1px solid var(--border);
+    color: var(--muted);
+    font-family: 'JetBrains Mono', monospace;
+    font-size: 8px;
+    padding: 1px 6px;
+    cursor: pointer;
+    border-radius: 2px;
+    transition: color 0.15s, border-color 0.15s;
+    letter-spacing: 0.05em;
+    white-space: nowrap;
+  }
+
+  .group-action-btn:hover {
+    color: var(--accent);
+    border-color: var(--accent);
+  }
+
+  .group-action-btn.disconnect:hover {
+    color: #ff4444;
+    border-color: #ff4444;
   }
 
   .group-arrow {

--- a/frontend/src/components/TunnelList.svelte
+++ b/frontend/src/components/TunnelList.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
+  import { createEventDispatcher } from "svelte";
   import type { TunnelConfig } from "../types";
-  import { tunnels, statuses, loading, getStatus, connectGroup, disconnectGroup } from "../stores/tunnels";
+  import { tunnels, statuses, loading, getStatus, connectGroup, disconnectGroup, renameGroup } from "../stores/tunnels";
   import TunnelCard from "./TunnelCard.svelte";
   import TunnelForm from "./TunnelForm.svelte";
   import TunnelLogs from "./TunnelLogs.svelte";
@@ -8,12 +9,16 @@
 
   export let filterGroup: string | null = null;
 
+  const dispatch = createEventDispatcher<{ groupRenamed: string }>();
+
   let showForm = false;
   let editingTunnel: TunnelConfig | null = null;
   let loggingTunnel: TunnelConfig | null = null;
   let terminalTunnel: TunnelConfig | null = null;
   let collapsedGroups: Record<string, boolean> = {};
   let collapsedFiles: Record<string, boolean> = {};
+  let renamingGroup = false;
+  let renameValue = "";
 
   function handleAdd() {
     editingTunnel = null;
@@ -122,9 +127,13 @@
     return sections;
   })();
 
-  $: hasMultipleFiles = fileSections.length > 1;
+  $: hasMultipleFiles = (() => {
+    const files = new Set(filteredTunnels.map(t => t.sourceFile || ""));
+    return files.size > 1;
+  })();
   $: isAllView = filterGroup === null;
   $: showInlineGroupTitle = filterGroup !== null && filterGroup !== "__pinned__" && filterGroup !== "__ungrouped__";
+  $: singleGroupAllConnected = showInlineGroupTitle ? groupAllConnected(filteredTunnels) : false;
   $: currentTitle = (() => {
     if (filterGroup === null) return "all tunnels";
     if (filterGroup === "__pinned__") return "pinned";
@@ -146,6 +155,31 @@
   function handleGroupDisconnect(groupName: string) {
     disconnectGroup(groupName);
   }
+
+  function startRenameGroup() {
+    if (filterGroup && filterGroup !== "__pinned__" && filterGroup !== "__ungrouped__") {
+      renameValue = filterGroup;
+      renamingGroup = true;
+    }
+  }
+
+  async function confirmRenameGroup() {
+    if (!renamingGroup || !renameValue.trim() || !filterGroup) {
+      renamingGroup = false;
+      return;
+    }
+    const newName = renameValue.trim();
+    const oldName = filterGroup;
+    renamingGroup = false;
+    if (oldName === newName) return;
+    await renameGroup(oldName, newName);
+    dispatch("groupRenamed", newName);
+  }
+
+  function handleRenameKeydown(e: KeyboardEvent) {
+    if (e.key === "Enter") confirmRenameGroup();
+    if (e.key === "Escape") renamingGroup = false;
+  }
 </script>
 
 {#if loggingTunnel}
@@ -165,8 +199,28 @@
     <TunnelForm tunnel={editingTunnel} on:close={handleFormClose} />
   {:else}
     <div class="list-header">
-      <div class="list-title" class:muted-title={!showInlineGroupTitle}>{currentTitle}</div>
-      <button class="add-btn" on:click={handleAdd}>+ new tunnel</button>
+      {#if renamingGroup}
+        <input
+          class="rename-input"
+          bind:value={renameValue}
+          on:keydown={handleRenameKeydown}
+          on:blur={confirmRenameGroup}
+          autofocus
+        />
+      {:else}
+        <div class="list-title">{currentTitle}</div>
+      {/if}
+      <div class="header-actions">
+        {#if showInlineGroupTitle}
+          {#if singleGroupAllConnected}
+            <button class="add-btn disconnect-btn" on:click={() => handleGroupDisconnect(filterGroup)}>disconnect all</button>
+          {:else}
+            <button class="add-btn" on:click={() => handleGroupConnect(filterGroup)}>connect all</button>
+          {/if}
+          <button class="add-btn" on:click={startRenameGroup} title="Rename group">✎</button>
+        {/if}
+        <button class="add-btn" on:click={handleAdd}>+ new tunnel</button>
+      </div>
     </div>
   {/if}
 
@@ -219,6 +273,28 @@
               </button>
               {#if !collapsedFiles[section.file]}
                 <div class="file-tunnels">
+                  {#if showInlineGroupTitle}
+                    {#each section.grouped.groups as group}
+                      {#each group.tunnels as tunnel (tunnel.id)}
+                        <TunnelCard
+                          {tunnel}
+                          status={getStatus($statuses, tunnel.id)}
+                          on:edit={handleEdit}
+                          on:logs={handleLogs}
+                          on:terminal={handleTerminal}
+                        />
+                      {/each}
+                    {/each}
+                    {#each section.grouped.ungrouped as tunnel (tunnel.id)}
+                      <TunnelCard
+                        {tunnel}
+                        status={getStatus($statuses, tunnel.id)}
+                        on:edit={handleEdit}
+                        on:logs={handleLogs}
+                        on:terminal={handleTerminal}
+                      />
+                    {/each}
+                  {:else}
                   {#if isAllView && section.grouped.groups.length > 0}
                     <div class="section-subheader">// Groups</div>
                   {/if}
@@ -263,10 +339,33 @@
                       on:terminal={handleTerminal}
                     />
                   {/each}
+                  {/if}
                 </div>
               {/if}
             </div>
           {:else}
+            {#if showInlineGroupTitle}
+              {#each section.grouped.groups as group}
+                {#each group.tunnels as tunnel (tunnel.id)}
+                  <TunnelCard
+                    {tunnel}
+                    status={getStatus($statuses, tunnel.id)}
+                    on:edit={handleEdit}
+                    on:logs={handleLogs}
+                    on:terminal={handleTerminal}
+                  />
+                {/each}
+              {/each}
+              {#each section.grouped.ungrouped as tunnel (tunnel.id)}
+                <TunnelCard
+                  {tunnel}
+                  status={getStatus($statuses, tunnel.id)}
+                  on:edit={handleEdit}
+                  on:logs={handleLogs}
+                  on:terminal={handleTerminal}
+                />
+              {/each}
+            {:else}
             {#if isAllView && section.grouped.groups.length > 0}
               <div class="section-subheader">// Groups</div>
             {/if}
@@ -311,6 +410,7 @@
                 on:terminal={handleTerminal}
               />
             {/each}
+            {/if}
           {/if}
         {/each}
       </div>
@@ -333,16 +433,32 @@
     gap: 8px;
   }
 
+  .rename-input {
+    flex: 1;
+    background: var(--surface2);
+    border: 1px solid var(--accent);
+    border-radius: 2px;
+    color: var(--text);
+    font-family: 'JetBrains Mono', monospace;
+    font-size: 11px;
+    text-transform: uppercase;
+    letter-spacing: 0.08em;
+    padding: 2px 6px;
+    outline: none;
+  }
+
+  .header-actions {
+    display: flex;
+    align-items: center;
+    gap: 6px;
+  }
+
   .list-title {
     font-family: 'JetBrains Mono', monospace;
     font-size: 11px;
     text-transform: uppercase;
     letter-spacing: 0.08em;
     color: var(--text);
-  }
-
-  .list-title.muted-title {
-    color: var(--muted);
   }
 
   .section-subheader {

--- a/frontend/src/stores/tunnels.ts
+++ b/frontend/src/stores/tunnels.ts
@@ -1,18 +1,24 @@
 import { writable, derived } from "svelte/store";
-import type { TunnelConfig, TunnelStatus, StatusEvent } from "../types";
-import { GetTunnels, GetTunnelStatuses, AddTunnel, UpdateTunnel, DeleteTunnel, ConnectTunnel, DisconnectTunnel, SelectFile, ImportPreview, ImportTunnels, SelectSaveFile, ExportTunnels, SetTunnelPinned, ConnectGroup, DisconnectGroup, RenameGroup } from "../../wailsjs/go/main/App";
+import type { TunnelConfig, TunnelStatus, StatusEvent, ConfigFileInfo } from "../types";
+import { GetTunnels, GetTunnelStatuses, AddTunnel, UpdateTunnel, DeleteTunnel, ConnectTunnel, DisconnectTunnel, SelectFile, ImportPreview, ImportTunnels, SelectSaveFile, ExportTunnels, SetTunnelPinned, ConnectGroup, DisconnectGroup, RenameGroup, GetIncludedConfigFiles } from "../../wailsjs/go/main/App";
 import { EventsOn } from "../../wailsjs/runtime/runtime";
 
 export const tunnels = writable<TunnelConfig[]>([]);
 export const statuses = writable<Record<string, StatusEvent>>({});
 export const loading = writable(true);
+export const includedConfigFiles = writable<ConfigFileInfo[]>([]);
 
 export async function loadTunnels() {
   loading.set(true);
   try {
-    const [cfgs, sts] = await Promise.all([GetTunnels(), GetTunnelStatuses()]);
+    const [cfgs, sts, includes] = await Promise.all([
+      GetTunnels(),
+      GetTunnelStatuses(),
+      GetIncludedConfigFiles(),
+    ]);
     tunnels.set(cfgs || []);
     statuses.set(sts || {});
+    includedConfigFiles.set(includes || []);
   } finally {
     loading.set(false);
   }

--- a/frontend/src/stores/tunnels.ts
+++ b/frontend/src/stores/tunnels.ts
@@ -1,6 +1,6 @@
 import { writable, derived } from "svelte/store";
 import type { TunnelConfig, TunnelStatus, StatusEvent } from "../types";
-import { GetTunnels, GetTunnelStatuses, AddTunnel, UpdateTunnel, DeleteTunnel, ConnectTunnel, DisconnectTunnel, SelectFile, ImportPreview, ImportTunnels, SelectSaveFile, ExportTunnels } from "../../wailsjs/go/main/App";
+import { GetTunnels, GetTunnelStatuses, AddTunnel, UpdateTunnel, DeleteTunnel, ConnectTunnel, DisconnectTunnel, SelectFile, ImportPreview, ImportTunnels, SelectSaveFile, ExportTunnels, SetTunnelPinned } from "../../wailsjs/go/main/App";
 import { EventsOn } from "../../wailsjs/runtime/runtime";
 
 export const tunnels = writable<TunnelConfig[]>([]);
@@ -39,6 +39,11 @@ export async function connectTunnel(id: string): Promise<void> {
 
 export async function disconnectTunnel(id: string): Promise<void> {
   await DisconnectTunnel(id);
+}
+
+export async function setTunnelPinned(id: string, pinned: boolean): Promise<void> {
+  await SetTunnelPinned(id, pinned);
+  await loadTunnels();
 }
 
 export function getStatus(

--- a/frontend/src/stores/tunnels.ts
+++ b/frontend/src/stores/tunnels.ts
@@ -1,6 +1,6 @@
 import { writable, derived } from "svelte/store";
 import type { TunnelConfig, TunnelStatus, StatusEvent } from "../types";
-import { GetTunnels, GetTunnelStatuses, AddTunnel, UpdateTunnel, DeleteTunnel, ConnectTunnel, DisconnectTunnel, SelectFile, ImportPreview, ImportTunnels, SelectSaveFile, ExportTunnels, SetTunnelPinned } from "../../wailsjs/go/main/App";
+import { GetTunnels, GetTunnelStatuses, AddTunnel, UpdateTunnel, DeleteTunnel, ConnectTunnel, DisconnectTunnel, SelectFile, ImportPreview, ImportTunnels, SelectSaveFile, ExportTunnels, SetTunnelPinned, ConnectGroup, DisconnectGroup, RenameGroup } from "../../wailsjs/go/main/App";
 import { EventsOn } from "../../wailsjs/runtime/runtime";
 
 export const tunnels = writable<TunnelConfig[]>([]);
@@ -44,6 +44,18 @@ export async function disconnectTunnel(id: string): Promise<void> {
 export async function setTunnelPinned(id: string, pinned: boolean): Promise<void> {
   await SetTunnelPinned(id, pinned);
   await loadTunnels();
+}
+
+export async function connectGroup(group: string): Promise<void> {
+  await ConnectGroup(group);
+}
+
+export async function disconnectGroup(group: string): Promise<void> {
+  await DisconnectGroup(group);
+}
+
+export async function renameGroup(oldName: string, newName: string): Promise<void> {
+  await RenameGroup(oldName, newName);
 }
 
 export function getStatus(

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -22,6 +22,7 @@ export interface TunnelConfig {
   autoConnect: boolean;
   pinned?: boolean;
   sourceFile?: string;
+  sourceFileLabel?: string;
 }
 
 export interface StatusEvent {
@@ -34,4 +35,9 @@ export interface LogEntry {
   timestamp: string;
   level: "info" | "warn" | "error";
   message: string;
+}
+
+export interface ConfigFileInfo {
+  path: string;
+  label: string;
 }

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -20,6 +20,7 @@ export interface TunnelConfig {
   color?: string;
   group: string;
   autoConnect: boolean;
+  pinned?: boolean;
   sourceFile?: string;
 }
 

--- a/frontend/wailsjs/go/main/App.d.ts
+++ b/frontend/wailsjs/go/main/App.d.ts
@@ -32,6 +32,8 @@ export function GetConfigFiles():Promise<Array<string>>;
 
 export function GetCurrentVersion():Promise<string>;
 
+export function GetIncludedConfigFiles():Promise<Array<config.ConfigFileInfo>>;
+
 export function GetTunnelLogs(arg1:string):Promise<Array<config.LogEntry>>;
 
 export function GetTunnelStatuses():Promise<Record<string, ssh.StatusEvent>>;

--- a/frontend/wailsjs/go/main/App.d.ts
+++ b/frontend/wailsjs/go/main/App.d.ts
@@ -12,9 +12,13 @@ export function ClearTunnelLogs(arg1:string):Promise<void>;
 
 export function CloseTerminal(arg1:string):Promise<void>;
 
+export function ConnectGroup(arg1:string):Promise<void>;
+
 export function ConnectTunnel(arg1:string):Promise<void>;
 
 export function DeleteTunnel(arg1:string):Promise<void>;
+
+export function DisconnectGroup(arg1:string):Promise<void>;
 
 export function DisconnectTunnel(arg1:string):Promise<void>;
 
@@ -41,6 +45,8 @@ export function ImportTunnels(arg1:string,arg2:Array<string>):Promise<number>;
 export function InstallUpdate():Promise<void>;
 
 export function OpenTerminal(arg1:string):Promise<string>;
+
+export function RenameGroup(arg1:string,arg2:string):Promise<void>;
 
 export function ResizeTerminal(arg1:string,arg2:number,arg3:number):Promise<void>;
 

--- a/frontend/wailsjs/go/main/App.d.ts
+++ b/frontend/wailsjs/go/main/App.d.ts
@@ -52,6 +52,8 @@ export function SetAutostart(arg1:boolean):Promise<void>;
 
 export function SetCloseToTray(arg1:boolean):Promise<void>;
 
+export function SetTunnelPinned(arg1:string,arg2:boolean):Promise<void>;
+
 export function SubmitPassphrase(arg1:string):Promise<void>;
 
 export function TerminalWrite(arg1:string,arg2:string):Promise<void>;

--- a/frontend/wailsjs/go/main/App.js
+++ b/frontend/wailsjs/go/main/App.js
@@ -98,6 +98,10 @@ export function SetCloseToTray(arg1) {
   return window['go']['main']['App']['SetCloseToTray'](arg1);
 }
 
+export function SetTunnelPinned(arg1, arg2) {
+  return window['go']['main']['App']['SetTunnelPinned'](arg1, arg2);
+}
+
 export function SubmitPassphrase(arg1) {
   return window['go']['main']['App']['SubmitPassphrase'](arg1);
 }

--- a/frontend/wailsjs/go/main/App.js
+++ b/frontend/wailsjs/go/main/App.js
@@ -18,12 +18,20 @@ export function CloseTerminal(arg1) {
   return window['go']['main']['App']['CloseTerminal'](arg1);
 }
 
+export function ConnectGroup(arg1) {
+  return window['go']['main']['App']['ConnectGroup'](arg1);
+}
+
 export function ConnectTunnel(arg1) {
   return window['go']['main']['App']['ConnectTunnel'](arg1);
 }
 
 export function DeleteTunnel(arg1) {
   return window['go']['main']['App']['DeleteTunnel'](arg1);
+}
+
+export function DisconnectGroup(arg1) {
+  return window['go']['main']['App']['DisconnectGroup'](arg1);
 }
 
 export function DisconnectTunnel(arg1) {
@@ -76,6 +84,10 @@ export function InstallUpdate() {
 
 export function OpenTerminal(arg1) {
   return window['go']['main']['App']['OpenTerminal'](arg1);
+}
+
+export function RenameGroup(arg1, arg2) {
+  return window['go']['main']['App']['RenameGroup'](arg1, arg2);
 }
 
 export function ResizeTerminal(arg1, arg2, arg3) {

--- a/frontend/wailsjs/go/main/App.js
+++ b/frontend/wailsjs/go/main/App.js
@@ -58,6 +58,10 @@ export function GetCurrentVersion() {
   return window['go']['main']['App']['GetCurrentVersion']();
 }
 
+export function GetIncludedConfigFiles() {
+  return window['go']['main']['App']['GetIncludedConfigFiles']();
+}
+
 export function GetTunnelLogs(arg1) {
   return window['go']['main']['App']['GetTunnelLogs'](arg1);
 }

--- a/frontend/wailsjs/go/models.ts
+++ b/frontend/wailsjs/go/models.ts
@@ -1,5 +1,19 @@
 export namespace config {
 	
+	export class ConfigFileInfo {
+	    path: string;
+	    label: string;
+	
+	    static createFrom(source: any = {}) {
+	        return new ConfigFileInfo(source);
+	    }
+	
+	    constructor(source: any = {}) {
+	        if ('string' === typeof source) source = JSON.parse(source);
+	        this.path = source["path"];
+	        this.label = source["label"];
+	    }
+	}
 	export class LogEntry {
 	    // Go type: time
 	    timestamp: any;
@@ -66,6 +80,7 @@ export namespace config {
 	    color?: string;
 	    group: string;
 	    autoConnect: boolean;
+	    pinned: boolean;
 	    sourceFile?: string;
 	    sourceFileLabel?: string;
 	
@@ -87,6 +102,7 @@ export namespace config {
 	        this.color = source["color"];
 	        this.group = source["group"];
 	        this.autoConnect = source["autoConnect"];
+	        this.pinned = source["pinned"];
 	        this.sourceFile = source["sourceFile"];
 	        this.sourceFileLabel = source["sourceFileLabel"];
 	    }
@@ -108,20 +124,6 @@ export namespace config {
 		    }
 		    return a;
 		}
-	}
-	export class ConfigFileInfo {
-	    path: string;
-	    label: string;
-	
-	    static createFrom(source: any = {}) {
-	        return new ConfigFileInfo(source);
-	    }
-	
-	    constructor(source: any = {}) {
-	        if ('string' === typeof source) source = JSON.parse(source);
-	        this.path = source["path"];
-	        this.label = source["label"];
-	    }
 	}
 
 }

--- a/frontend/wailsjs/go/models.ts
+++ b/frontend/wailsjs/go/models.ts
@@ -67,6 +67,7 @@ export namespace config {
 	    group: string;
 	    autoConnect: boolean;
 	    sourceFile?: string;
+	    sourceFileLabel?: string;
 	
 	    static createFrom(source: any = {}) {
 	        return new TunnelConfig(source);
@@ -87,6 +88,7 @@ export namespace config {
 	        this.group = source["group"];
 	        this.autoConnect = source["autoConnect"];
 	        this.sourceFile = source["sourceFile"];
+	        this.sourceFileLabel = source["sourceFileLabel"];
 	    }
 	
 		convertValues(a: any, classs: any, asMap: boolean = false): any {
@@ -106,6 +108,20 @@ export namespace config {
 		    }
 		    return a;
 		}
+	}
+	export class ConfigFileInfo {
+	    path: string;
+	    label: string;
+	
+	    static createFrom(source: any = {}) {
+	        return new ConfigFileInfo(source);
+	    }
+	
+	    constructor(source: any = {}) {
+	        if ('string' === typeof source) source = JSON.parse(source);
+	        this.path = source["path"];
+	        this.label = source["label"];
+	    }
 	}
 
 }

--- a/internal/config/models.go
+++ b/internal/config/models.go
@@ -30,19 +30,25 @@ type PortForward struct {
 
 // TunnelConfig holds the persistent configuration for a single SSH tunnel.
 type TunnelConfig struct {
-	ID           string        `json:"id"`
-	Name         string        `json:"name"`
-	Host         string        `json:"host"`
-	Port         int           `json:"port"`
-	User         string        `json:"user"`
-	KeyPath      string        `json:"keyPath"`
-	PortForwards []PortForward `json:"portForwards"`
-	ProxyCommand string        `json:"proxyCommand,omitempty"`
-	ProxyJump    string        `json:"proxyJump,omitempty"`
-	Color        string        `json:"color,omitempty"`
-	Group        string        `json:"group"`
-	AutoConnect  bool          `json:"autoConnect"`
-	Pinned       bool          `json:"pinned"`
-	SourceFile   string        `json:"sourceFile,omitempty"`
+	ID              string        `json:"id"`
+	Name            string        `json:"name"`
+	Host            string        `json:"host"`
+	Port            int           `json:"port"`
+	User            string        `json:"user"`
+	KeyPath         string        `json:"keyPath"`
+	PortForwards    []PortForward `json:"portForwards"`
+	ProxyCommand    string        `json:"proxyCommand,omitempty"`
+	ProxyJump       string        `json:"proxyJump,omitempty"`
+	Color           string        `json:"color,omitempty"`
+	Group           string        `json:"group"`
+	AutoConnect     bool          `json:"autoConnect"`
+	Pinned          bool          `json:"pinned"`
+	SourceFile      string        `json:"sourceFile,omitempty"`
+	SourceFileLabel string        `json:"sourceFileLabel,omitempty"`
 }
 
+// ConfigFileInfo describes an SSH config file that can be edited.
+type ConfigFileInfo struct {
+	Path  string `json:"path"`
+	Label string `json:"label"`
+}

--- a/internal/config/models.go
+++ b/internal/config/models.go
@@ -42,6 +42,7 @@ type TunnelConfig struct {
 	Color        string        `json:"color,omitempty"`
 	Group        string        `json:"group"`
 	AutoConnect  bool          `json:"autoConnect"`
+	Pinned       bool          `json:"pinned"`
 	SourceFile   string        `json:"sourceFile,omitempty"`
 }
 

--- a/internal/config/store.go
+++ b/internal/config/store.go
@@ -93,6 +93,7 @@ func (s *Store) AddTunnel(t TunnelConfig) error {
 	if t.SourceFile == "" {
 		t.SourceFile = s.filePath
 	}
+	t.SourceFileLabel = sshconfig.CollapseTildePath(t.SourceFile)
 	s.tunnels = append(s.tunnels, t)
 	return nil
 }
@@ -148,6 +149,7 @@ func (s *Store) UpdateTunnel(t TunnelConfig) error {
 
 	// Preserve the source file
 	t.SourceFile = targetFile
+	t.SourceFileLabel = sshconfig.CollapseTildePath(targetFile)
 	// Update ID to match new name on rename
 	t.ID = t.Name
 	s.tunnels[idx] = t
@@ -240,6 +242,30 @@ func (s *Store) GetConfigFiles() []string {
 	return files
 }
 
+// GetIncludedConfigFiles returns the list of files referenced by Include
+// directives, beginning with the main config file.
+func (s *Store) GetIncludedConfigFiles() ([]ConfigFileInfo, error) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	files, err := sshconfig.IncludedConfigFiles(s.filePath)
+	if err != nil {
+		return nil, err
+	}
+	result := make([]ConfigFileInfo, 0, len(files))
+	seen := make(map[string]bool)
+	for _, file := range files {
+		if file == "" || seen[file] {
+			continue
+		}
+		seen[file] = true
+		result = append(result, ConfigFileInfo{
+			Path:  file,
+			Label: sshconfig.CollapseTildePath(file),
+		})
+	}
+	return result, nil
+}
+
 func toHostEntry(t TunnelConfig) sshconfig.HostEntry {
 	e := sshconfig.HostEntry{
 		Alias:        t.Name,
@@ -268,19 +294,20 @@ func toHostEntry(t TunnelConfig) sshconfig.HostEntry {
 
 func fromHostEntry(e sshconfig.HostEntry) TunnelConfig {
 	t := TunnelConfig{
-		ID:           e.Alias,
-		Name:         e.Alias,
-		Host:         e.HostName,
-		Port:         e.Port,
-		User:         e.User,
-		KeyPath:      e.IdentityFile,
-		ProxyCommand: e.ProxyCommand,
-		ProxyJump:    e.ProxyJump,
-		Color:        e.Color,
-		Group:        e.Group,
-		AutoConnect:  e.AutoConnect,
-		Pinned:       e.Pinned,
-		SourceFile:   e.SourceFile,
+		ID:              e.Alias,
+		Name:            e.Alias,
+		Host:            e.HostName,
+		Port:            e.Port,
+		User:            e.User,
+		KeyPath:         e.IdentityFile,
+		ProxyCommand:    e.ProxyCommand,
+		ProxyJump:       e.ProxyJump,
+		Color:           e.Color,
+		Group:           e.Group,
+		AutoConnect:     e.AutoConnect,
+		Pinned:          e.Pinned,
+		SourceFile:      e.SourceFile,
+		SourceFileLabel: sshconfig.CollapseTildePath(e.SourceFile),
 	}
 	for _, pf := range e.PortForwards {
 		t.PortForwards = append(t.PortForwards, PortForward{

--- a/internal/config/store.go
+++ b/internal/config/store.go
@@ -252,6 +252,7 @@ func toHostEntry(t TunnelConfig) sshconfig.HostEntry {
 		Color:        t.Color,
 		Group:        t.Group,
 		AutoConnect:  t.AutoConnect,
+		Pinned:       t.Pinned,
 		SourceFile:   t.SourceFile,
 	}
 	for _, pf := range t.PortForwards {
@@ -278,6 +279,7 @@ func fromHostEntry(e sshconfig.HostEntry) TunnelConfig {
 		Color:        e.Color,
 		Group:        e.Group,
 		AutoConnect:  e.AutoConnect,
+		Pinned:       e.Pinned,
 		SourceFile:   e.SourceFile,
 	}
 	for _, pf := range e.PortForwards {

--- a/internal/config/store_test.go
+++ b/internal/config/store_test.go
@@ -7,6 +7,8 @@ import (
 	"strings"
 	"sync"
 	"testing"
+
+	"ssh-tunnel-manager/internal/sshconfig"
 )
 
 func tempSSHConfigPath(t *testing.T) string {
@@ -402,6 +404,56 @@ Include `+confDir+`/*.conf
 	}
 	if strings.Contains(string(data), "Host work-server") {
 		t.Error("included file should no longer contain work-server")
+	}
+}
+
+func TestGetIncludedConfigFiles(t *testing.T) {
+	dir := t.TempDir()
+	confDir := filepath.Join(dir, "config.d")
+	if err := os.MkdirAll(confDir, 0o755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+
+	included := filepath.Join(confDir, "work.conf")
+	writeSSHConfig(t, included, `Host work-server
+    HostName work.example.com
+    User deploy
+`)
+
+	mainConfig := filepath.Join(dir, "config")
+	writeSSHConfig(t, mainConfig, `Host main-server
+    HostName main.example.com
+    User admin
+
+Include `+confDir+`/*.conf
+`)
+
+	s, err := NewStoreWithPath(mainConfig)
+	if err != nil {
+		t.Fatalf("create store: %v", err)
+	}
+
+	files, err := s.GetIncludedConfigFiles()
+	if err != nil {
+		t.Fatalf("GetIncludedConfigFiles: %v", err)
+	}
+	if len(files) != 2 {
+		t.Fatalf("expected 2 files, got %d", len(files))
+	}
+
+	absMain, _ := filepath.Abs(mainConfig)
+	absIncluded, _ := filepath.Abs(included)
+	if files[0].Path != absMain {
+		t.Errorf("files[0].Path = %q, want %q", files[0].Path, absMain)
+	}
+	if files[1].Path != absIncluded {
+		t.Errorf("files[1].Path = %q, want %q", files[1].Path, absIncluded)
+	}
+	if files[0].Label != sshconfig.CollapseTildePath(absMain) {
+		t.Errorf("files[0].Label = %q, want %q", files[0].Label, sshconfig.CollapseTildePath(absMain))
+	}
+	if files[1].Label != sshconfig.CollapseTildePath(absIncluded) {
+		t.Errorf("files[1].Label = %q, want %q", files[1].Label, sshconfig.CollapseTildePath(absIncluded))
 	}
 }
 

--- a/internal/sshconfig/parser.go
+++ b/internal/sshconfig/parser.go
@@ -32,6 +32,7 @@ type HostEntry struct {
 	Color        string
 	Group        string
 	AutoConnect  bool
+	Pinned       bool
 	SourceFile   string // absolute path to the file this entry was parsed from
 }
 
@@ -137,6 +138,7 @@ func Parse(scanner *bufio.Scanner) ([]HostEntry, error) {
 	var metaGroup string
 	var metaColor string
 	var metaAutoConnect bool
+	var metaPinned bool
 	inMatch := false
 
 	for scanner.Scan() {
@@ -153,6 +155,8 @@ func Parse(scanner *bufio.Scanner) ([]HostEntry, error) {
 				metaColor = val
 			case "autoconnect":
 				metaAutoConnect = val == "true"
+			case "pinned":
+				metaPinned = val == "true"
 			}
 			continue
 		}
@@ -167,6 +171,7 @@ func Parse(scanner *bufio.Scanner) ([]HostEntry, error) {
 			metaGroup = ""
 			metaColor = ""
 			metaAutoConnect = false
+			metaPinned = false
 			continue
 		}
 
@@ -183,6 +188,7 @@ func Parse(scanner *bufio.Scanner) ([]HostEntry, error) {
 				metaGroup = ""
 				metaColor = ""
 				metaAutoConnect = false
+				metaPinned = false
 				continue
 			}
 
@@ -192,10 +198,12 @@ func Parse(scanner *bufio.Scanner) ([]HostEntry, error) {
 				Color:       metaColor,
 				Group:       metaGroup,
 				AutoConnect: metaAutoConnect,
+				Pinned:      metaPinned,
 			}
 			metaGroup = ""
 			metaColor = ""
 			metaAutoConnect = false
+			metaPinned = false
 			continue
 		}
 
@@ -206,6 +214,7 @@ func Parse(scanner *bufio.Scanner) ([]HostEntry, error) {
 				metaGroup = ""
 				metaColor = ""
 				metaAutoConnect = false
+				metaPinned = false
 			}
 			continue
 		}
@@ -269,6 +278,9 @@ func RenderHostBlock(e HostEntry) string {
 	}
 	if e.AutoConnect {
 		b.WriteString("# stm:autoconnect=true\n")
+	}
+	if e.Pinned {
+		b.WriteString("# stm:pinned=true\n")
 	}
 
 	fmt.Fprintf(&b, "Host %s\n", e.Alias)

--- a/internal/sshconfig/parser.go
+++ b/internal/sshconfig/parser.go
@@ -465,3 +465,67 @@ func extractIncludePattern(line, baseDir string) string {
 func CollapseTildePath(path string) string {
 	return collapseTilde(path)
 }
+
+// IncludedConfigFiles returns the main config path followed by the files
+// referenced by any Include directives found while scanning the given file.
+func IncludedConfigFiles(path string) ([]string, error) {
+	absPath, err := filepath.Abs(path)
+	if err != nil {
+		return nil, fmt.Errorf("resolving path %s: %w", path, err)
+	}
+
+	seen := make(map[string]bool)
+	files := []string{}
+
+	var collect func(string) error
+	collect = func(p string) error {
+		abs, err := filepath.Abs(p)
+		if err != nil {
+			return fmt.Errorf("resolving path %s: %w", p, err)
+		}
+		if seen[abs] {
+			return nil
+		}
+		seen[abs] = true
+		files = append(files, abs)
+
+		f, err := os.Open(abs)
+		if err != nil {
+			if os.IsNotExist(err) {
+				return nil
+			}
+			return fmt.Errorf("opening ssh config %s: %w", abs, err)
+		}
+		defer f.Close()
+
+		scanner := bufio.NewScanner(f)
+		baseDir := filepath.Dir(abs)
+		for scanner.Scan() {
+			trimmed := strings.TrimSpace(scanner.Text())
+			if isIncludeDirective(trimmed) {
+				pattern := extractIncludePattern(trimmed, baseDir)
+				if pattern == "" {
+					continue
+				}
+				matches, err := filepath.Glob(pattern)
+				if err != nil {
+					return fmt.Errorf("expanding Include glob %q: %w", pattern, err)
+				}
+				for _, match := range matches {
+					if err := collect(match); err != nil {
+						return err
+					}
+				}
+			}
+		}
+		if err := scanner.Err(); err != nil {
+			return fmt.Errorf("scanning ssh config %s: %w", abs, err)
+		}
+		return nil
+	}
+
+	if err := collect(absPath); err != nil {
+		return nil, err
+	}
+	return files, nil
+}


### PR DESCRIPTION
## Co zostało zrobione

### 🔖 Przypinanie hostów
- Nowe pole `pinned` w modelu hosta (backend Go + frontend types)
- Przycisk 📌 na karcie hosta do przypięcia/odpięcia
- Widok **"All"**: kolejność — Przypięte → pogrupowane → nieprzypisane
- Widok **grupy**: przypięte hosty się nie wyświetlają (tylko członkowie grupy)
- Sidebar: sekcja **"Przypięte"** nad listą grup — klik filtruje do tylko przypiętych

### 🎨 Unified label colors
- Labelki/badges przy hostach mają ten sam kolor co nazwy hostów (lepsza czytelność)
- Zmiany w `TunnelCard.svelte` i `TunnelList.svelte`

### ✅ Auto-connect toggle
- Checkbox "auto-connect" w `TunnelForm.svelte` wygląda identycznie jak toggle "Start on Login" w `SettingsPanel.svelte`

## Pliki
- `internal/config/models.go` — pole `Pinned`
- `internal/config/store.go` — zapis stanu
- `app.go` — metody `PinTunnel` / `UnpinTunnel`
- `frontend/src/types.ts` — typ TS
- `frontend/src/stores/tunnels.ts` — store
- `frontend/src/components/GroupSidebar.svelte` — sekcja Przypięte
- `frontend/src/components/TunnelList.svelte` — sortowanie i filtrowanie
- `frontend/src/components/TunnelCard.svelte` — pin button + label colors
- `frontend/src/components/TunnelForm.svelte` — toggle style auto-connect